### PR TITLE
Fix MyBinder build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools~=59.6.0
+setuptools>=64
 networkx~=2.8
 pandas~=1.5.3
 scikit-learn

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.18
+python-3.9


### PR DESCRIPTION
Hi! This fixes the MyBinder build by using the Python version format expected by current repo2docker and aligning the setuptools requirement with `setup.py`.

I also tested the image locally with Docker; JupyterLab and Quarto start successfully.

You can test the branch here before merging:

[Launch on MyBinder](https://mybinder.org/v2/gh/arnim/delab-trees/fix%2Fmybinder-build?urlpath=lab%2Ftree%2Findex.ipynb)